### PR TITLE
refactor: reduce error domain

### DIFF
--- a/internal/app/service/auth/trader_service_test.go
+++ b/internal/app/service/auth/trader_service_test.go
@@ -39,7 +39,7 @@ func TestBarterService_RegisterTrader(t *testing.T) {
 
 				trader := args.Trader
 				password := args.Password
-				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.BaseError{})
+				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.DomainError{})
 				mock.AuthServer.EXPECT().RegisterAccount(gomock.Any(), trader.Email, password).Return(trader.UID, nil)
 				mock.TraderRepo.EXPECT().CreateTrader(gomock.Any(), gomock.Any()).Return(&trader, nil)
 
@@ -55,9 +55,9 @@ func TestBarterService_RegisterTrader(t *testing.T) {
 
 				trader := args.Trader
 				password := args.Password
-				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.BaseError{})
+				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.DomainError{})
 				mock.AuthServer.EXPECT().RegisterAccount(gomock.Any(), trader.Email, password).Return(trader.UID, nil)
-				mock.TraderRepo.EXPECT().CreateTrader(gomock.Any(), gomock.Any()).Return(nil, common.BaseError{})
+				mock.TraderRepo.EXPECT().CreateTrader(gomock.Any(), gomock.Any()).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service
@@ -71,8 +71,8 @@ func TestBarterService_RegisterTrader(t *testing.T) {
 
 				trader := args.Trader
 				password := args.Password
-				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.BaseError{})
-				mock.AuthServer.EXPECT().RegisterAccount(gomock.Any(), trader.Email, password).Return("", common.BaseError{})
+				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.DomainError{})
+				mock.AuthServer.EXPECT().RegisterAccount(gomock.Any(), trader.Email, password).Return("", common.DomainError{})
 
 				service := buildService(mock)
 				return service
@@ -158,7 +158,7 @@ func TestBarterService_LoginTrader(t *testing.T) {
 				trader := args.Trader
 				password := args.Password
 				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(&trader, nil)
-				mock.AuthServer.EXPECT().AuthenticateAccount(gomock.Any(), trader.Email, password).Return(common.BaseError{})
+				mock.AuthServer.EXPECT().AuthenticateAccount(gomock.Any(), trader.Email, password).Return(common.DomainError{})
 
 				service := buildService(mock)
 				return service
@@ -171,7 +171,7 @@ func TestBarterService_LoginTrader(t *testing.T) {
 				mock := buildServiceMock(ctrl)
 
 				trader := args.Trader
-				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.BaseError{})
+				mock.TraderRepo.EXPECT().GetTraderByEmail(gomock.Any(), trader.Email).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service

--- a/internal/app/service/barter/exchange_service_test.go
+++ b/internal/app/service/barter/exchange_service_test.go
@@ -59,7 +59,7 @@ func TestBarterService_ExchangeGoods(t *testing.T) {
 				targetGood := args.TargetGood
 				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), requestGood.ID).Return(&requestGood, nil)
 				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), targetGood.ID).Return(&targetGood, nil)
-				mock.GoodRepo.EXPECT().UpdateGoods(gomock.Any(), gomock.Any()).Return(nil, common.BaseError{})
+				mock.GoodRepo.EXPECT().UpdateGoods(gomock.Any(), gomock.Any()).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service
@@ -74,7 +74,7 @@ func TestBarterService_ExchangeGoods(t *testing.T) {
 				requestGood := args.RequestGood
 				targetGood := args.TargetGood
 				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), requestGood.ID).Return(&requestGood, nil)
-				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), targetGood.ID).Return(nil, common.BaseError{})
+				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), targetGood.ID).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service
@@ -101,7 +101,7 @@ func TestBarterService_ExchangeGoods(t *testing.T) {
 				mock := buildServiceMock(ctrl)
 
 				requestGood := args.RequestGood
-				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), requestGood.ID).Return(nil, common.BaseError{})
+				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), requestGood.ID).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service

--- a/internal/app/service/barter/good_service_test.go
+++ b/internal/app/service/barter/good_service_test.go
@@ -69,7 +69,7 @@ func TestBarterService_RemoveMyGood(t *testing.T) {
 				mock := buildServiceMock(ctrl)
 
 				good := args.Good
-				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), good.ID).Return(nil, common.BaseError{})
+				mock.GoodRepo.EXPECT().GetGoodByID(gomock.Any(), good.ID).Return(nil, common.DomainError{})
 
 				service := buildService(mock)
 				return service

--- a/internal/domain/common/error.go
+++ b/internal/domain/common/error.go
@@ -74,31 +74,22 @@ func (e DomainError) Detail() map[string]interface{} {
 	return e.detail
 }
 
-type ErrorOption func(Error)
+type ErrorOption func(*DomainError)
 
 func WithMsg(msg string) ErrorOption {
-	return func(e Error) {
-		switch err := e.(type) {
-		case *DomainError:
-			err.clientMsg = msg
-		}
+	return func(e *DomainError) {
+		e.clientMsg = msg
 	}
 }
 
 func WithStatus(status int) ErrorOption {
-	return func(e Error) {
-		switch err := e.(type) {
-		case *DomainError:
-			err.remoteStatus = status
-		}
+	return func(e *DomainError) {
+		e.remoteStatus = status
 	}
 }
 
 func WithDetail(detail map[string]interface{}) ErrorOption {
-	return func(e Error) {
-		switch err := e.(type) {
-		case *DomainError:
-			err.detail = detail
-		}
+	return func(e *DomainError) {
+		e.detail = detail
 	}
 }

--- a/internal/domain/common/error.go
+++ b/internal/domain/common/error.go
@@ -41,61 +41,6 @@ func WithDetail(detail map[string]interface{}) ErrorOption {
 	}
 }
 
-type ErrorCode struct {
-	Name       string
-	StatusCode int
-}
-
-/*
-	General error codes
-*/
-
-var ErrorCodeInternalProcess = ErrorCode{
-	Name:       "INTERNAL_PROCESS",
-	StatusCode: http.StatusInternalServerError,
-}
-
-/*
-	Authentication and Authorization error codes
-*/
-
-var ErrorCodeAuthPermissionDenied = ErrorCode{
-	Name:       "AUTH_PERMISSION_DENIED",
-	StatusCode: http.StatusForbidden,
-}
-
-var ErrorCodeAuthNotAuthenticated = ErrorCode{
-	Name:       "AUTH_NOT_AUTHENTICATED",
-	StatusCode: http.StatusUnauthorized,
-}
-
-/*
-	Resource-related error codes
-*/
-
-var ErrorCodeResourceNotFound = ErrorCode{
-	Name:       "RESOURCE_NOT_FOUND",
-	StatusCode: http.StatusNotFound,
-}
-
-/*
-	Parameter-related error codes
-*/
-
-var ErrorCodeParameterInvalid = ErrorCode{
-	Name:       "PARAMETER_INVALID",
-	StatusCode: http.StatusBadRequest,
-}
-
-/*
-	Remote server-related error codes
-*/
-
-var ErrorCodeRemoteProcess = ErrorCode{
-	Name:       "REMOTE_PROCESS_ERROR",
-	StatusCode: http.StatusBadGateway,
-}
-
 // BaseError used for expressing errors occurring in application.
 type BaseError struct {
 	err          error

--- a/internal/domain/common/error.go
+++ b/internal/domain/common/error.go
@@ -44,7 +44,6 @@ func WithDetail(detail map[string]interface{}) ErrorOption {
 type ErrorCode struct {
 	Name       string
 	StatusCode int
-	Category   string // backward-compatible the current error format TODO: remove after deprecation
 }
 
 /*
@@ -54,7 +53,6 @@ type ErrorCode struct {
 var ErrorCodeInternalProcess = ErrorCode{
 	Name:       "INTERNAL_PROCESS",
 	StatusCode: http.StatusInternalServerError,
-	Category:   "INTERNAL_ERROR",
 }
 
 /*
@@ -64,13 +62,11 @@ var ErrorCodeInternalProcess = ErrorCode{
 var ErrorCodeAuthPermissionDenied = ErrorCode{
 	Name:       "AUTH_PERMISSION_DENIED",
 	StatusCode: http.StatusForbidden,
-	Category:   "RESOURCE_ERROR",
 }
 
 var ErrorCodeAuthNotAuthenticated = ErrorCode{
 	Name:       "AUTH_NOT_AUTHENTICATED",
 	StatusCode: http.StatusUnauthorized,
-	Category:   "PARAMETER_ERROR",
 }
 
 /*
@@ -80,7 +76,6 @@ var ErrorCodeAuthNotAuthenticated = ErrorCode{
 var ErrorCodeResourceNotFound = ErrorCode{
 	Name:       "RESOURCE_NOT_FOUND",
 	StatusCode: http.StatusNotFound,
-	Category:   "RESOURCE_ERROR",
 }
 
 /*
@@ -90,7 +85,6 @@ var ErrorCodeResourceNotFound = ErrorCode{
 var ErrorCodeParameterInvalid = ErrorCode{
 	Name:       "PARAMETER_INVALID",
 	StatusCode: http.StatusBadRequest,
-	Category:   "PARAMETER_ERROR",
 }
 
 /*
@@ -100,7 +94,6 @@ var ErrorCodeParameterInvalid = ErrorCode{
 var ErrorCodeRemoteProcess = ErrorCode{
 	Name:       "REMOTE_PROCESS_ERROR",
 	StatusCode: http.StatusBadGateway,
-	Category:   "REMOTE_SERVER_ERROR",
 }
 
 // BaseError used for expressing errors occurring in application.
@@ -144,13 +137,6 @@ func (e BaseError) Name() string {
 		return "UNKNOWN_ERROR"
 	}
 	return e.code.Name
-}
-
-func (e BaseError) Category() string {
-	if e.code.Category == "" {
-		return "UNKNOWN_ERROR"
-	}
-	return e.code.Category
 }
 
 func (e BaseError) ClientMsg() string {

--- a/internal/domain/common/error_code.go
+++ b/internal/domain/common/error_code.go
@@ -1,0 +1,58 @@
+package common
+
+import "net/http"
+
+type ErrorCode struct {
+	Name       string
+	StatusCode int
+}
+
+/*
+	General error codes
+*/
+
+var ErrorCodeInternalProcess = ErrorCode{
+	Name:       "INTERNAL_PROCESS",
+	StatusCode: http.StatusInternalServerError,
+}
+
+/*
+	Authentication and Authorization error codes
+*/
+
+var ErrorCodeAuthPermissionDenied = ErrorCode{
+	Name:       "AUTH_PERMISSION_DENIED",
+	StatusCode: http.StatusForbidden,
+}
+
+var ErrorCodeAuthNotAuthenticated = ErrorCode{
+	Name:       "AUTH_NOT_AUTHENTICATED",
+	StatusCode: http.StatusUnauthorized,
+}
+
+/*
+	Resource-related error codes
+*/
+
+var ErrorCodeResourceNotFound = ErrorCode{
+	Name:       "RESOURCE_NOT_FOUND",
+	StatusCode: http.StatusNotFound,
+}
+
+/*
+	Parameter-related error codes
+*/
+
+var ErrorCodeParameterInvalid = ErrorCode{
+	Name:       "PARAMETER_INVALID",
+	StatusCode: http.StatusBadRequest,
+}
+
+/*
+	Remote server-related error codes
+*/
+
+var ErrorCodeRemoteProcess = ErrorCode{
+	Name:       "REMOTE_PROCESS_ERROR",
+	StatusCode: http.StatusBadGateway,
+}

--- a/internal/domain/common/error_test.go
+++ b/internal/domain/common/error_test.go
@@ -79,7 +79,6 @@ func TestBaseError_ErrorMapping(t *testing.T) {
 		Name                   string
 		TestError              Error
 		ExpectErrorName        string
-		ExpectCategory         string
 		ExpectHTTPStatus       int
 		ExpectRemoteHTTPStatus int
 	}{
@@ -87,42 +86,36 @@ func TestBaseError_ErrorMapping(t *testing.T) {
 			Name:             "internal process",
 			TestError:        NewError(ErrorCodeInternalProcess, nil),
 			ExpectErrorName:  ErrorCodeInternalProcess.Name,
-			ExpectCategory:   ErrorCodeInternalProcess.Category,
 			ExpectHTTPStatus: http.StatusInternalServerError,
 		},
 		{
 			Name:             "permission denied",
 			TestError:        NewError(ErrorCodeAuthPermissionDenied, nil),
 			ExpectErrorName:  ErrorCodeAuthPermissionDenied.Name,
-			ExpectCategory:   ErrorCodeAuthPermissionDenied.Category,
 			ExpectHTTPStatus: http.StatusForbidden,
 		},
 		{
 			Name:             "not authenticated",
 			TestError:        NewError(ErrorCodeAuthNotAuthenticated, nil),
 			ExpectErrorName:  ErrorCodeAuthNotAuthenticated.Name,
-			ExpectCategory:   ErrorCodeAuthNotAuthenticated.Category,
 			ExpectHTTPStatus: http.StatusUnauthorized,
 		},
 		{
 			Name:             "invalid parameter",
 			TestError:        NewError(ErrorCodeParameterInvalid, nil),
 			ExpectErrorName:  ErrorCodeParameterInvalid.Name,
-			ExpectCategory:   ErrorCodeParameterInvalid.Category,
 			ExpectHTTPStatus: http.StatusBadRequest,
 		},
 		{
 			Name:             "resource not found",
 			TestError:        NewError(ErrorCodeResourceNotFound, nil),
 			ExpectErrorName:  ErrorCodeResourceNotFound.Name,
-			ExpectCategory:   ErrorCodeResourceNotFound.Category,
 			ExpectHTTPStatus: http.StatusNotFound,
 		},
 		{
 			Name:                   "remote process",
 			TestError:              NewError(ErrorCodeRemoteProcess, nil, WithStatus(http.StatusBadRequest)),
 			ExpectErrorName:        ErrorCodeRemoteProcess.Name,
-			ExpectCategory:         ErrorCodeRemoteProcess.Category,
 			ExpectHTTPStatus:       http.StatusBadGateway,
 			ExpectRemoteHTTPStatus: http.StatusBadRequest,
 		},
@@ -130,7 +123,6 @@ func TestBaseError_ErrorMapping(t *testing.T) {
 			Name:             "unknown error",
 			TestError:        NewError(ErrorCode{}, nil),
 			ExpectErrorName:  "UNKNOWN_ERROR",
-			ExpectCategory:   "UNKNOWN_ERROR",
 			ExpectHTTPStatus: http.StatusInternalServerError,
 		},
 	}
@@ -143,7 +135,6 @@ func TestBaseError_ErrorMapping(t *testing.T) {
 			var baseError BaseError
 			if errors.As(err, &baseError) {
 				assert.Equal(t, c.ExpectErrorName, baseError.Name())
-				assert.Equal(t, c.ExpectCategory, baseError.Category())
 				assert.Equal(t, c.ExpectHTTPStatus, baseError.HTTPStatus())
 				assert.Equal(t, c.ExpectRemoteHTTPStatus, baseError.RemoteHTTPStatus())
 			} else {

--- a/internal/domain/common/error_test.go
+++ b/internal/domain/common/error_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBaseError_Option(t *testing.T) {
+func TestDomainError_Option(t *testing.T) {
 	t.Parallel()
 
 	msg := "random client message"
@@ -50,28 +50,28 @@ func TestBaseError_Option(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			err := c.TestError
 
-			var baseError BaseError
-			if errors.As(err, &baseError) {
+			var domainError DomainError
+			if errors.As(err, &domainError) {
 				if c.WithMsg {
-					assert.EqualValues(t, msg, baseError.ClientMsg())
+					assert.EqualValues(t, msg, domainError.ClientMsg())
 				}
 				if c.WitStatus {
-					assert.EqualValues(t, status, baseError.RemoteHTTPStatus())
+					assert.EqualValues(t, status, domainError.RemoteHTTPStatus())
 				}
 				if c.WitDeniedPermission {
-					assert.Contains(t, baseError.Error(), "no permission to")
+					assert.Contains(t, domainError.Error(), "no permission to")
 				}
 				if c.WithDetail {
-					assert.Contains(t, baseError.Detail(), "channel_id")
-					assert.Contains(t, baseError.Detail(), "member_name")
-					assert.Equal(t, detail, baseError.Detail())
+					assert.Contains(t, domainError.Detail(), "channel_id")
+					assert.Contains(t, domainError.Detail(), "member_name")
+					assert.Equal(t, detail, domainError.Detail())
 				}
 			}
 		})
 	}
 }
 
-func TestBaseError_ErrorMapping(t *testing.T) {
+func TestDomainError_ErrorMapping(t *testing.T) {
 	t.Parallel()
 
 	// Test cases
@@ -132,11 +132,11 @@ func TestBaseError_ErrorMapping(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			err := c.TestError
 
-			var baseError BaseError
-			if errors.As(err, &baseError) {
-				assert.Equal(t, c.ExpectErrorName, baseError.Name())
-				assert.Equal(t, c.ExpectHTTPStatus, baseError.HTTPStatus())
-				assert.Equal(t, c.ExpectRemoteHTTPStatus, baseError.RemoteHTTPStatus())
+			var domainError DomainError
+			if errors.As(err, &domainError) {
+				assert.Equal(t, c.ExpectErrorName, domainError.Name())
+				assert.Equal(t, c.ExpectHTTPStatus, domainError.HTTPStatus())
+				assert.Equal(t, c.ExpectRemoteHTTPStatus, domainError.RemoteHTTPStatus())
 			} else {
 				t.Error("failed to match error type")
 			}

--- a/internal/router/response.go
+++ b/internal/router/response.go
@@ -46,7 +46,6 @@ func parseError(err error) ErrorMessage {
 	return ErrorMessage{
 		Name:       baseError.Name(),
 		Code:       baseError.HTTPStatus(),
-		Category:   ErrorCategory(baseError.Category()),
 		Message:    baseError.ClientMsg(),
 		RemoteCode: baseError.RemoteHTTPStatus(),
 		Detail:     baseError.Detail(),

--- a/internal/router/response.go
+++ b/internal/router/response.go
@@ -38,16 +38,16 @@ func respondWithError(c *gin.Context, err error) {
 }
 
 func parseError(err error) ErrorMessage {
-	var baseError common.BaseError
+	var domainError common.DomainError
 	// We don't check if errors.As is valid or not
-	// because an empty common.BaseError would return default error data.
-	_ = errors.As(err, &baseError)
+	// because an empty common.DomainError would return default error data.
+	_ = errors.As(err, &domainError)
 
 	return ErrorMessage{
-		Name:       baseError.Name(),
-		Code:       baseError.HTTPStatus(),
-		Message:    baseError.ClientMsg(),
-		RemoteCode: baseError.RemoteHTTPStatus(),
-		Detail:     baseError.Detail(),
+		Name:       domainError.Name(),
+		Code:       domainError.HTTPStatus(),
+		Message:    domainError.ClientMsg(),
+		RemoteCode: domainError.RemoteHTTPStatus(),
+		Detail:     domainError.Detail(),
 	}
 }


### PR DESCRIPTION
## 🤔 Why

To improve the readability.

## 💡 How

- Move error codes to another file.
- Rename `BaseError` to `DomainError`.
- Remove unnecessary abstraction.
