### PR TITLE
fix init-local-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ migrate-db-force-%:
 
 # Only used for local dev
 init-local-db:
-	docker exec cantata-postgres bash -c "psql -U cb_test -d cb_test -f /testdata/init_local_dev.sql"
+	docker exec cb-postgres bash -c "psql -U cb_test -d cb_test -f /testdata/init_local_dev.sql"


### PR DESCRIPTION
## 🤔 Why

Hi team, I found a bug while running this repo locally. The issue is simple. The `init-local-db` is broken because of the false PostgreSQL container naming.

## 💡 How

Commit a simple fix by renaming the container name.

## Additional issue while running the repo

I don't know what  `jq` does, but it blocked the building process in my local machine. I removed it and my app works fine, so I wonder if `jq` is necessary here. 

```bash
run: build
	./bin/barter \
	--database_dsn=$(DATABASE_DSN) \
	| jq
```